### PR TITLE
Fixed event listener url on UnifiOS

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,7 +73,11 @@ module.exports = class UnifiEvents extends EventEmitter {
 
     _listen() {
         const cookies = this.jar.getCookieString(this.controller.href);
-        this.ws = new WebSocket(`wss://${this.controller.host}/wss/s/${this.opts.site}/events`, {
+        let eventsUrl = `wss://${this.controller.host}/wss/s/${this.opts.site}/events`;
+        if (this.opts.unifios) {
+            eventsUrl = `wss://${this.controller.host}/proxy/network/wss/s/${this.opts.site}/events`;
+        } 
+        this.ws = new WebSocket(eventsUrl, {
             perMessageDeflate: false,
             rejectUnauthorized: !this.opts.insecure,
             headers: {

--- a/index.js
+++ b/index.js
@@ -154,7 +154,7 @@ module.exports = class UnifiEvents extends EventEmitter {
     }
 
     _url(path) {
-        if (this.unifios) {
+        if (this.opts.unifios) {
             // unifios using an proxy, set extra path
             if (path.indexOf('/') === 0) {
                 return `${this.controller.href}proxy/network/${path}`;


### PR DESCRIPTION
Event listener could not connect to a UDM running UnifOS 1.7.0. 
This change fixes that.